### PR TITLE
[pcied] Fix pcied failure to load due to 'pcied NameError: name 'self' is not defined'

### DIFF
--- a/sonic-pcied/scripts/pcied
+++ b/sonic-pcied/scripts/pcied
@@ -10,7 +10,7 @@ import signal
 import sys
 import threading
 
-from sonic_py_common import daemon_base, device_info
+from sonic_py_common import daemon_base, device_info, logger
 from swsscommon import swsscommon
 
 #
@@ -35,6 +35,8 @@ PCIEUTIL_LOAD_ERROR = 2
 
 platform_pcieutil = None
 
+log = logger.Logger(SYSLOG_IDENTIFIER)
+
 exit_code = 0
 
 # wrapper functions to call the platform api
@@ -45,12 +47,12 @@ def load_platform_pcieutil():
         from sonic_platform.pcie import Pcie
         _platform_pcieutil = Pcie(platform_path)
     except ImportError as e:
-        self.log_error("Failed to load platform Pcie module. Error : {}".format(str(e)), True)
+        log.log_notice("Failed to load platform Pcie module. Error : {}, Fallback to default module".format(str(e)), True)
         try:
             from sonic_platform_base.sonic_pcie.pcie_common import PcieUtil
             _platform_pcieutil = PcieUtil(platform_path)
         except ImportError as e:
-            self.log_error("Failed to load default PcieUtil module. Error : {}".format(str(e)), True)
+            log.log_error("Failed to load default PcieUtil module. Error : {}".format(str(e)), True)
     return _platform_pcieutil
 
 def read_id_file(device_name):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

Resolves issue - https://github.com/Azure/sonic-buildimage/issues/7993

- Fixes wrong log line when Pcie module does not exists that causes the pcied daemon to enter FATAL state.
- Change log level of line "Failed to load platform Pcie module" to notice since this is not an error flow, this is part of the normal loading flow we expect when a vendor didn't supply a Pcie class.


#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Load image, check pcied daemon status.

#### Additional Information (Optional)
